### PR TITLE
Setting the timezone of the trining to UTC

### DIFF
--- a/sites/default/config/views.view.events_home.yml
+++ b/sites/default/config/views.view.events_home.yml
@@ -1209,7 +1209,7 @@ display:
           click_sort_column: value
           type: daterange_custom
           settings:
-            timezone_override: America/New_York
+            timezone_override: UTC
             date_format: 'g:i A'
             separator: '-'
           group_column: value


### PR DESCRIPTION
This means no conversion is done from libcal, which is not sending a timezone.  This means the site is assuming the libcal timezone is UTC when it is local time