### PR TITLE
New URL for Research Data Traning and Workshop Feed.

### DIFF
--- a/sites/default/config/migrate_plus.migration.event_rss_importer.yml
+++ b/sites/default/config/migrate_plus.migration.event_rss_importer.yml
@@ -12,7 +12,7 @@ label: 'Import Event RSS feed'
 source:
   plugin: url
   data_fetcher_plugin: http
-  urls: 'https://libcal.princeton.edu/rss.php?m=cat&iid=771&cid=12260&cat=49413'
+  urls: 'https://libcal.princeton.edu/rss.php?cid=12260&m=tag&tag=3372'
   data_parser_plugin: simple_xml
   item_selector: /rss/channel/item
   fields:


### PR DESCRIPTION
Per @VickieKarasic this event feed has a new URL to pull form due to libcal tag re-org. 