### PR TITLE
Update documentation to use prds-prod2

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Drupal site for Princeton Research Data Service
 1. `cp drush/sites/example.site.yml drush/sites/researchdata.site.yml`
 1. Uncomment the alias blocks in the `drush/sites/researchdata.site.yml`.
 1. `lando start`
-1. `lando drush @researchdata.prod sql-dump --structure-tables-list='watchdog,sessions,cas_data_login,history,captcha_sessions,cache,cache_*' --result-file=/tmp/dump.sql; scp pulsys@prds-prod1:/tmp/dump.sql .`
+1. `lando drush @researchdata.prod sql-dump --structure-tables-list='watchdog,sessions,cas_data_login,history,captcha_sessions,cache,cache_*' --result-file=/tmp/dump.sql; scp pulsys@prds-prod2:/tmp/dump.sql .`
 1. `lando db-import dump.sql`
 1. `lando drush rsync @researchdata.prod:%files @researchdata.local:%files`
 1. In order to get the value for `$settings['hash_salt']`, run `ls sites/default/files | grep "config" | sed "s/config_\(\S*\)/\1/"` on the command line, and put the result in your `sites/defaults/settings.php`

--- a/docs/drupal-core-upgrade.md
+++ b/docs/drupal-core-upgrade.md
@@ -12,7 +12,7 @@ Check https://researchdata.princeton.edu/admin/reports/updates to see if there a
 1. Pull the production database (This assumes you have followed the configuration steps in the README.md
    ```
    lando drush @researchdata.prod sql-dump --structure-tables-list='watchdog,sessions,cas_data_login,history,captcha_sessions,cache,cache_*' --result-file=/tmp/dump.sql
-   scp pulsys@prds-prod1:/tmp/dump.sql .
+   scp pulsys@prds-prod2:/tmp/dump.sql .
    lando db-import dump.sql
    lando drush cache:rebuild
    ```

--- a/drush/sites/example.site.yml
+++ b/drush/sites/example.site.yml
@@ -6,7 +6,7 @@
 #   uri: 'http://researchdata.lndo.site'
 
 # prod:
-#   host: prds-prod1.princeton.edu
+#   host: prds-prod2.princeton.edu
 #   options:
 #     command-specific:
 #       sql-sync:


### PR DESCRIPTION
Currently, we don't have a prds-prod1 box, but the documentation points to it in multiple places.  This PR updates the documentation to point to prds-prod2 instead.